### PR TITLE
Support for encoder, version bumps

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,4 +15,4 @@ By default the bindings are generated using the headers and libraries that ought
 - [ ] Examples
 
 [1]: https://github.com/rust-lang/rust-bindgen
-[2]: https://github.com/OpenVisualCloud/SVT-AV1
+[2]: https://gitlab.com/AOMediaCodec/SVT-AV1/-/releases

--- a/svt-av1-sys/Cargo.toml
+++ b/svt-av1-sys/Cargo.toml
@@ -10,13 +10,13 @@ build = "build.rs"
 readme = "../README.md"
 
 [package.metadata.system-deps]
-SvtAv1Enc = "0.8"
+SvtAv1Enc = "^1"
 
 [features]
 build_sources = []
 
 [build-dependencies]
-bindgen = "0.53.1"
-system-deps = "1.3"
+bindgen = "0.65.1"
+system-deps = "6.1"
 
 [dependencies]

--- a/svt-av1-sys/build.rs
+++ b/svt-av1-sys/build.rs
@@ -14,12 +14,12 @@ fn format_write(builder: bindgen::Builder) -> String {
 
 fn main() {
     let libs = system_deps::Config::new().probe().unwrap();
-    let headers = libs.get("SvtAv1Enc").unwrap().include_paths.clone();
+    let headers = libs.get_by_name("SvtAv1Enc").unwrap().include_paths.clone();
 
     let mut builder = bindgen::builder()
-        .header("data/enc.h")
-        .blacklist_type("max_align_t")
-        .whitelist_function("svt_av1_enc.*")
+        .header("data/wrapper.h")
+        .blocklist_type("max_align_t")
+        .allowlist_function("svt_av1.*")
         .size_t_is_usize(true)
         .default_enum_style(bindgen::EnumVariation::ModuleConsts);
 
@@ -32,7 +32,7 @@ fn main() {
 
     let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
 
-    let mut file = File::create(out_path.join("enc.rs")).unwrap();
+    let mut file = File::create(out_path.join("svtav1.rs")).unwrap();
 
     let _ = file.write(s.as_bytes());
 }

--- a/svt-av1-sys/data/enc.h
+++ b/svt-av1-sys/data/enc.h
@@ -1,2 +1,0 @@
-#include "EbSvtAv1ErrorCodes.h"
-#include "EbSvtAv1Enc.h"

--- a/svt-av1-sys/data/wrapper.h
+++ b/svt-av1-sys/data/wrapper.h
@@ -1,0 +1,7 @@
+#include "EbSvtAv1.h"
+#include "EbSvtAv1ErrorCodes.h"
+#include "EbSvtAv1ExtFrameBuf.h"
+#include "EbSvtAv1Formats.h"
+#include "EbSvtAv1Metadata.h"
+#include "EbSvtAv1Dec.h"
+#include "EbSvtAv1Enc.h"

--- a/svt-av1-sys/src/lib.rs
+++ b/svt-av1-sys/src/lib.rs
@@ -6,11 +6,11 @@
 #[cfg_attr(feature = "cargo-clippy", allow(const_static_lifetime))]
 #[cfg_attr(feature = "cargo-clippy", allow(unreadable_literal))]
 
-pub mod enc {
-    include!(concat!(env!("OUT_DIR"), "/enc.rs"));
+pub mod SvtAV1 {
+    include!(concat!(env!("OUT_DIR"), "/svtav1.rs"));
 }
 
-pub use enc::*;
+pub use SvtAV1::*;
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
Closes #2

* Bump the version of bindgen, per the docs should only use the latest version.
* Bump the version of system-deps
* Include Encoder, rename enc.rs to svtav1.rs since it includes both encoder and decoder
* Update URL to official SVT-AV1 repo.